### PR TITLE
Test Avro serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,21 @@
 	</licenses>
 
 	<properties>
-		<kafka.version>2.5.1</kafka.version>
+		<avro.version>1.9.2</avro.version>
+		<kafka.version>2.4.1</kafka.version>
+		<confluent.version>5.5.2</confluent.version>
 	</properties>
-	
+
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>https://packages.confluent.io/maven/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.airlift</groupId>
@@ -37,9 +49,43 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>${confluent.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka-clients</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.glassfish.hk2.external</groupId>
+					<artifactId>jakarta.inject</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.avro</groupId>
+			<artifactId>avro</artifactId>
+			<version>${avro.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
 			<version>${kafka.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.airlift</groupId>
+			<artifactId>log-manager</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-schema-registry-client</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 		<!-- trino SPI -->
@@ -98,4 +144,64 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+				<configuration>
+					<source>1.11</source>
+					<target>1.11</target>
+				</configuration>
+			</plugin>
+
+
+			<!--for specific record-->
+			<plugin>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro-maven-plugin</artifactId>
+				<version>${avro.version}</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>schema</goal>
+							<goal>protocol</goal>
+							<goal>idl-protocol</goal>
+						</goals>
+						<configuration>
+							<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+							<stringType>String</stringType>
+							<createSetters>false</createSetters>
+							<enableDecimalLogicalType>true</enableDecimalLogicalType>
+							<fieldVisibility>private</fieldVisibility>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!--force discovery of generated classes-->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.basedir}/target/generated-sources/avro</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/src/main/java/io/trino/plugin/eventstream/EventStreamEventListener.java
+++ b/src/main/java/io/trino/plugin/eventstream/EventStreamEventListener.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.eventstream;
 
 import io.airlift.log.Logger;
+import io.trino.QueryCreatedEventV1;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
@@ -40,11 +41,24 @@ public class EventStreamEventListener
     @Override
     public void queryCreated(QueryCreatedEvent queryCreatedEvent)
     {
-        kafkaProducer.send(
-                new ProducerRecord<>(TOPIC_PRESTO_EVENT,
-                        queryCreatedEvent.getMetadata().getQueryId(),
-                        queryCreatedEvent.toString()));
-        log.debug("Sent queryCreated event. query id %s", queryCreatedEvent.getMetadata().getQueryId());
+        QueryCreatedEventV1 created = QueryCreatedEventV1.newBuilder()
+                .setQuery(queryCreatedEvent.getMetadata().getQuery())
+                .setQueryID(queryCreatedEvent.getMetadata().getQueryId())
+                .setPrinciple(queryCreatedEvent.getContext().getPrincipal().toString())
+                .setUserAgent(queryCreatedEvent.getContext().getUserAgent().toString())
+                .setRemoteClientAddress(queryCreatedEvent.getContext().getRemoteClientAddress().toString())
+                .setClientInfo(queryCreatedEvent.getContext().getClientInfo().toString())
+                .build();
+        try {
+            log.info(created.toString());
+            kafkaProducer.send(
+                    new ProducerRecord<>(TOPIC_PRESTO_EVENT,
+                            queryCreatedEvent.getMetadata().getQuery(),
+                            created));
+        }
+        catch (Exception e) {
+            log.error(e);
+        }
     }
 
     @Override

--- a/src/main/java/io/trino/plugin/eventstream/EventStreamEventListenerFactory.java
+++ b/src/main/java/io/trino/plugin/eventstream/EventStreamEventListenerFactory.java
@@ -15,6 +15,7 @@ package io.trino.plugin.eventstream;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.EventListenerFactory;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -53,17 +54,22 @@ public class EventStreamEventListenerFactory
         ImmutableMap.Builder builder = ImmutableMap.<String, Object>builder();
 
         Iterator<String> it = config.keySet().iterator();
-
         while (it.hasNext()) {
             String key = it.next();
-            // String kafkaConfigKey = key.replaceFirst(REGEX_CONFIG_PREFIX,
-            //         "");
-            log.debug("Loading event-listener config %s", key);
-            builder.put(key, config.get(key));
+            log.info(key);
+            log.info(config.get(key));
+            if (key.equals("value.serializer")) {
+                // Had to use serializer even though received from event-stream for maven to compile
+                builder.put(key, KafkaAvroSerializer.class.getName());
+            }
+            else {
+                builder.put(key, config.get(key));
+            }
+//            String kafkaConfigKey = key.replaceFirst(REGEX_CONFIG_PREFIX,
+//                     "");
         }
-
         // TODO design ways to config/code serializer
-
+        log.info("*** Builder map ***", builder.build());
         return builder.build();
     }
 

--- a/src/main/resources/avro/querycreated-v1.avsc
+++ b/src/main/resources/avro/querycreated-v1.avsc
@@ -1,0 +1,21 @@
+{
+  "type": "record",
+  "namespace": "io.trino",
+  "name": "QueryCreatedEventV1",
+  "fields": [
+    { "name": "Query", "type": "string", "doc": "Query Statement" },
+    { "name": "QueryID", "type": "string", "doc": "Query ID" },
+    { "name": "Principle", "type": ["null" ,"string"], "doc": "Principle",
+      "default": null
+    },
+    { "name": "UserAgent", "type": ["null" ,"string"], "doc": "UserAgent",
+      "default": null
+    },
+    { "name": "RemoteClientAddress", "type": ["null" ,"string"], "doc": "RemoteClientAddress",
+      "default": null
+    },
+    { "name": "ClientInfo", "type": ["null" ,"string"], "doc": "ClientInfo",
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
Supports - https://github.com/IBM/trino-event-stream/issues/5

- Added Avro Value Serializer for `QueryCreatedEvent`  trino-event-streams
- Currently the serializer fails to register,connect to the `schema-registry` 

## Issues
When trying to test the serializer, unable to find the schema registry and fails with the below error 

```
2021-04-27T21:47:07.182Z	INFO	main	org.apache.kafka.common.utils.AppInfoParser	Kafka version: 2.4.1
2021-04-27T21:47:07.182Z	INFO	main	org.apache.kafka.common.utils.AppInfoParser	Kafka commitId: c57222ae8cd7866b
2021-04-27T21:47:07.182Z	INFO	main	org.apache.kafka.common.utils.AppInfoParser	Kafka startTimeMs: 1619560027177
2021-04-27T21:47:07.185Z	INFO	main	io.trino.eventlistener.EventListenerManager	-- Loaded event listener /data/trino/etc/event-listener.properties --
2021-04-27T21:47:07.231Z	INFO	main	io.trino.server.Server	======== SERVER STARTED ========
2021-04-27T21:47:07.587Z	INFO	kafka-producer-network-thread | producer-1	org.apache.kafka.clients.Metadata	[Producer clientId=producer-1] Cluster ID: 24PSBvqpScawqPcQAbSupw
2021-04-27T21:47:36.546Z	INFO	dispatcher-query-0	io.trino.plugin.eventstream.EventStreamEventListener	{"Query": "SHOW CATALOGS", "QueryID": "20210427_214736_00000_c88vh", "Principle": "Optional[preethi.anantharaman1@ibm.com]", "UserAgent": "Optional[StatementClientV1/355]", "RemoteClientAddress": "Optional[192.168.0.1]", "ClientInfo": "Optional.empty"}
2021-04-27T21:47:36.567Z	WARN	kafka-producer-network-thread | producer-1	org.apache.kafka.clients.NetworkClient	[Producer clientId=producer-1] Error while fetching metadata with correlation id 3 : {trino.event=LEADER_NOT_AVAILABLE}
2021-04-27T21:47:36.683Z	WARN	dispatcher-query-0	io.trino.eventlistener.EventListenerManager	Failed to publish QueryCreatedEvent for query 20210427_214736_00000_c88vh
java.lang.NoClassDefFoundError: javax/ws/rs/core/UriBuilder
	at io.confluent.kafka.schemaregistry.client.rest.RestService.registerSchema(RestService.java:492)
	at io.confluent.kafka.schemaregistry.client.rest.RestService.registerSchema(RestService.java:486)
	at io.confluent.kafka.schemaregistry.client.rest.RestService.registerSchema(RestService.java:459)
	at io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient.registerAndGetId(CachedSchemaRegistryClient.java:206)
	at io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient.register(CachedSchemaRegistryClient.java:268)
	at io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient.register(CachedSchemaRegistryClient.java:244)
	at io.confluent.kafka.serializers.AbstractKafkaAvroSerializer.serializeImpl(AbstractKafkaAvroSerializer.java:75)
	at io.confluent.kafka.serializers.KafkaAvroSerializer.serialize(KafkaAvroSerializer.java:59)
	at org.apache.kafka.common.serialization.Serializer.serialize(Serializer.java:62)
	at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:903)
	at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:865)
	at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:752)
	at io.trino.plugin.eventstream.EventStreamEventListener.queryCreated(EventStreamEventListener.java:54)
	at io.trino.eventlistener.EventListenerManager.queryCreated(EventListenerManager.java:150)
	at io.trino.event.QueryMonitor.queryCreatedEvent(QueryMonitor.java:132)
	at io.trino.dispatcher.LocalDispatchQueryFactory.createDispatchQuery(LocalDispatchQueryFactory.java:120)
	at io.trino.dispatcher.DispatchManager.createQueryInternal(DispatchManager.java:198)
	at io.trino.dispatcher.DispatchManager.lambda$createQuery$0(DispatchManager.java:148)
	at io.trino.$gen.Trino_354____20210427_214653_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: javax.ws.rs.core.UriBuilder
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:89)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 22 more
```