### PR TITLE
serialize split completed events

### DIFF
--- a/src/main/resources/avro/querycreated-v1.avsc
+++ b/src/main/resources/avro/querycreated-v1.avsc
@@ -3,6 +3,7 @@
   "namespace": "io.trino.plugin.eventstream",
   "name": "QueryCreatedEventV1",
   "fields": [
+    { "name": "QueryType", "type": "string", "doc": "Query Run Type" },
     { "name": "Query", "type": "string", "doc": "Query Statement" },
     { "name": "QueryID", "type": "string", "doc": "Query ID" },
     { "name": "Principle", "type": ["null" ,"string"], "doc": "Principle",

--- a/src/main/resources/avro/splitcompleted-v1.avsc
+++ b/src/main/resources/avro/splitcompleted-v1.avsc
@@ -1,13 +1,11 @@
 {
   "type": "record",
   "namespace": "io.trino.plugin.eventstream",
-  "name": "QueryCompletedEventV1",
+  "name": "SplitCompletedEventV1",
   "fields": [
     { "name": "QueryType", "type": "string", "doc": "Query Run Type" },
-    { "name": "Query", "type": "string", "doc": "Query Statement" },
     { "name": "QueryID", "type": "string", "doc": "Query ID" },
     { "name": "QueryStartTime", "type": "string", "doc": "Query Created Time"},
-    { "name": "QueryEndTime", "type": "string", "doc": "Query End Time"},
-    { "name": "OutputRows", "type": "long", "doc": "Output Rows from Query"}
+    { "name": "QueryEndTime", "type": "string", "doc": "Query End Time"}
   ]
 }


### PR DESCRIPTION
Supports #5 

1. Serialize `SplitCompletedEvent`
2. Added QueryType for `QueryCreated` and `QueryCompleted` Events.

### Notes 

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/53986990/117222797-f11e5880-add1-11eb-805f-3be094fc1394.png">
