### PR TITLE
upgrade trino version to 359

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.trino</groupId>
 		<artifactId>trino-root</artifactId>
-		<version>356</version>
+		<version>359</version>
 	</parent>
 
 	<artifactId>trino-event-stream</artifactId>


### PR DESCRIPTION
Upgrading trino version from 356 to 359 to fix security vulnerabilities

